### PR TITLE
Fix private chat metadata

### DIFF
--- a/app/search/[id]/page.tsx
+++ b/app/search/[id]/page.tsx
@@ -28,15 +28,13 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   if (chat.visibility === 'public') {
     title = chat.title;
   }
-  // if chat is private, return title
+  // if chat is private, only the owner can see the title
   if (chat.visibility === 'private') {
-    if (!user) {
+    if (!user || user.id !== chat.userId) {
       title = 'Scira Chat';
+    } else {
+      title = chat.title;
     }
-    if (user!.id !== chat.userId) {
-      title = 'Scira Chat';
-    }
-    title = chat.title;
   }
   return {
     title: title, description: "A search in scira.ai",


### PR DESCRIPTION
## Summary
- ensure private chat titles are hidden from unauthorized users

## Testing
- `pnpm install`
- `pnpm lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_684269c590148322ad0bcf5f42e6b656
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Private chat titles are now hidden from users who are not the chat owner. Unauthorized users will see a generic title instead.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved privacy by ensuring private chat titles are only visible to their owners; other users will see a generic title instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->