### PR TITLE
Add DB scripts and update env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ XAI_API_KEY=your_xai_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 GROQ_API_KEY=your_groq_api_key_here
+GOOGLE_GENERATIVE_AI_API_KEY=your_google_generative_ai_api_key_here
 
 # Development & Sandbox
 DAYTONA_API_KEY=your_daytona_api_key_here
@@ -50,6 +51,7 @@ SMITHERY_API_KEY=your_smithery_api_key_here
 
 # Cron & Security
 CRON_SECRET=your_cron_secret_here
+ALLOWED_ORIGINS=http://localhost:3000
 
 # Client-side Environment Variables (NEXT_PUBLIC_*)
 NEXT_PUBLIC_MAPBOX_TOKEN=your_public_mapbox_token_here

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "next lint",
-    "knip": "knip"
+    "knip": "knip",
+    "db:generate": "drizzle-kit generate --config ./drizzle.config.ts",
+    "db:push": "drizzle-kit push --config ./drizzle.config.ts",
+    "db:studio": "drizzle-kit studio --config ./drizzle.config.ts",
+    "db:up": "drizzle-kit up --config ./drizzle.config.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",


### PR DESCRIPTION
## Summary
- add Drizzle database scripts in `package.json`
- include missing env vars in `.env.example`

## Testing
- `npx drizzle-kit --help`


------
https://chatgpt.com/codex/tasks/task_b_68445c31307c8322997e171d5166771d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Drizzle database scripts to package.json and updated .env.example with missing environment variables.

- **New Features**
  - Added db:generate, db:push, db:studio, and db:up scripts for Drizzle.
  - Included GOOGLE_GENERATIVE_AI_API_KEY and ALLOWED_ORIGINS in .env.example.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment variable examples to include new API key and allowed origins entries.
  - Added new database management scripts for generating artifacts, pushing schema changes, launching a studio interface, and applying migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->